### PR TITLE
Fix TimeBomb setup and launcher controls

### DIFF
--- a/Linux/assets/icon/timebomb.svg
+++ b/Linux/assets/icon/timebomb.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="22" fill="#25282d"/>
+  <circle cx="64" cy="70" r="40" fill="#33373d" stroke="#0b0d10" stroke-width="6"/>
+  <path d="M48 28h32v13H48z" fill="#33373d" stroke="#0b0d10" stroke-width="6" stroke-linejoin="round"/>
+  <path d="M77 29c9-13 20-12 28-4" fill="none" stroke="#a0ffa0" stroke-width="7" stroke-linecap="round"/>
+  <path d="M96 25c11 3 13 12 10 21" fill="none" stroke="#23ff23" stroke-width="5" stroke-linecap="round"/>
+  <text x="64" y="82" text-anchor="middle" font-family="Arial, sans-serif" font-size="34" font-weight="700" fill="#23ff23">TB</text>
+  <path d="M36 103h56" stroke="#a0ffa0" stroke-width="5" stroke-linecap="round" opacity=".75"/>
+</svg>

--- a/Linux/install.sh
+++ b/Linux/install.sh
@@ -44,6 +44,7 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PYTHON_DIR="$SCRIPT_DIR/python"
 VENV_DIR="$PYTHON_DIR/venv"
+PYTHON_BIN=""
 
 # Detect the correct gtk-layer-shell package name for apt-based systems.
 # Debian 12 / Ubuntu 22.04 ship it as 'gtk-layer-shell0'; older releases
@@ -82,22 +83,22 @@ detect_package_manager() {
         GTK_LAYER_SHELL_PKG=$(detect_gtk_layer_shell_pkg)
         detect_gi_dev_pkg
 
-        PACKAGES="python3 python3-venv python3-pip libcairo2-dev ${GTK_LAYER_SHELL_PKG} libgtk-3-0 python3-gi gir1.2-gtk-3.0 ${GI_DEV_PKG} pulseaudio-utils fontconfig x11-utils"
+        PACKAGES="python3 python3-venv python3-pip libcairo2-dev ${GTK_LAYER_SHELL_PKG} libgtk-3-0 python3-gi gir1.2-gtk-3.0 ${GI_DEV_PKG} python3-evdev python3-pyudev pulseaudio-utils fontconfig x11-utils"
     elif command -v dnf &> /dev/null; then
         PKG_MANAGER="dnf"
         PKG_INSTALL="sudo dnf install -y"
-        PACKAGES="python3 python3-devel gcc cairo-devel cairo-gobject-devel gtk-layer-shell gtk3 python3-gobject pulseaudio-utils fontconfig xdpyinfo"
+        PACKAGES="python3 python3-devel gcc cairo-devel cairo-gobject-devel gtk-layer-shell gtk3 python3-gobject python3-evdev python3-pyudev pulseaudio-utils fontconfig xdpyinfo"
         PYGOBJECT_PIN=""
     elif command -v pacman &> /dev/null; then
         PKG_MANAGER="pacman"
         PKG_INSTALL="sudo pacman -S --needed --noconfirm"
-        PACKAGES="python cairo gtk-layer-shell gtk3 python-gobject pulseaudio fontconfig xorg-xdpyinfo"
+        PACKAGES="python cairo gtk-layer-shell gtk3 python-gobject python-evdev python-pyudev pulseaudio fontconfig xorg-xdpyinfo"
         ARCH_AUDIO_CONFLICT=true
         PYGOBJECT_PIN=""
     elif command -v zypper &> /dev/null; then
         PKG_MANAGER="zypper"
         PKG_INSTALL="sudo zypper install -y"
-        PACKAGES="python3 python3-devel gcc make pkg-config cairo-devel python3-cairo-devel libgtk-layer-shell0 typelib-1_0-GtkLayerShell-0_1 gtk3 python3-gobject pulseaudio-utils fontconfig xdpyinfo"
+        PACKAGES="python3 python3-devel gcc make pkg-config cairo-devel python3-cairo-devel libgtk-layer-shell0 typelib-1_0-GtkLayerShell-0_1 gtk3 python3-gobject python3-evdev python3-pyudev pulseaudio-utils fontconfig xdpyinfo"
         PYGOBJECT_PIN=""
     else
         echo "ERROR: Could not detect package manager!"
@@ -121,17 +122,29 @@ detect_package_manager() {
     fi
 }
 
+select_python() {
+    if [ -n "$TIMEBOMB_PYTHON" ]; then
+        PYTHON_BIN="$TIMEBOMB_PYTHON"
+    elif [ -x /usr/bin/python3 ]; then
+        PYTHON_BIN="/usr/bin/python3"
+    else
+        PYTHON_BIN="$(command -v python3 2>/dev/null || true)"
+    fi
+
+    if [ -z "$PYTHON_BIN" ] || [ ! -x "$PYTHON_BIN" ]; then
+        echo "ERROR: Python 3 is not installed!"
+        echo "Install it with: $PKG_INSTALL python3"
+        exit 1
+    fi
+}
+
 echo "[1/8] Detecting system..."
 detect_package_manager
 
 echo ""
 echo "[2/8] Checking Python installation..."
-if ! command -v python3 &> /dev/null; then
-    echo "ERROR: Python 3 is not installed!"
-    echo "Install it with: $PKG_INSTALL python3"
-    exit 1
-fi
-echo "✓ Python 3 found: $(python3 --version)"
+select_python
+echo "✓ Python 3 found: $("$PYTHON_BIN" --version) at $PYTHON_BIN"
 
 echo ""
 echo "[3/8] Installing system dependencies..."
@@ -153,7 +166,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ $REPLY == "1" ]]; then
             echo "Using pipewire-pulse (already installed)"
             echo "Removing pulseaudio from package list..."
-            sudo pacman -S --needed --noconfirm python cairo gtk-layer-shell gtk3 python-gobject fontconfig xorg-xdpyinfo || {
+            sudo pacman -S --needed --noconfirm python cairo gtk-layer-shell gtk3 python-gobject python-evdev python-pyudev fontconfig xorg-xdpyinfo || {
                 echo "WARNING: Some packages failed to install."
                 echo "TimeBomb may not work properly without all dependencies."
             }
@@ -162,7 +175,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             sudo pacman -S --needed pulseaudio || {
                 echo "WARNING: Failed to install pulseaudio."
             }
-            sudo pacman -S --needed --noconfirm python cairo gtk-layer-shell gtk3 python-gobject fontconfig xorg-xdpyinfo || {
+            sudo pacman -S --needed --noconfirm python cairo gtk-layer-shell gtk3 python-gobject python-evdev python-pyudev fontconfig xorg-xdpyinfo || {
                 echo "WARNING: Some packages failed to install."
             }
         fi
@@ -207,7 +220,7 @@ if [ -d "$VENV_DIR" ]; then
     rm -rf "$VENV_DIR"
 fi
 
-python3 -m venv "$VENV_DIR" || {
+"$PYTHON_BIN" -m venv --system-site-packages "$VENV_DIR" || {
     echo "ERROR: Failed to create virtual environment!"
     echo "Make sure python3-venv is installed:"
     echo "  $PKG_INSTALL python3-venv"
@@ -216,14 +229,28 @@ python3 -m venv "$VENV_DIR" || {
 echo "✓ Virtual environment created at: $VENV_DIR"
 
 echo ""
-echo "[6/8] Installing Python packages in venv..."
-"$VENV_DIR/bin/pip" install --upgrade pip
-"$VENV_DIR/bin/pip" install evdev "PyGObject${PYGOBJECT_PIN}" pyudev || {
-    echo "ERROR: Failed to install Python packages!"
-    echo "This usually means system dependencies are missing."
-    exit 1
-}
-echo "✓ Python packages installed"
+echo "[6/8] Checking Python packages in venv..."
+
+MISSING_PIP_PACKAGES=()
+if ! "$VENV_DIR/bin/python3" -c "import evdev" &>/dev/null; then
+    MISSING_PIP_PACKAGES+=("evdev")
+fi
+if ! "$VENV_DIR/bin/python3" -c "import pyudev" &>/dev/null; then
+    MISSING_PIP_PACKAGES+=("pyudev")
+fi
+if ! "$VENV_DIR/bin/python3" -c "import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk" &>/dev/null; then
+    MISSING_PIP_PACKAGES+=("PyGObject${PYGOBJECT_PIN}")
+fi
+
+if [ ${#MISSING_PIP_PACKAGES[@]} -gt 0 ]; then
+    "$VENV_DIR/bin/pip" install --upgrade pip
+    "$VENV_DIR/bin/pip" install "${MISSING_PIP_PACKAGES[@]}" || {
+        echo "ERROR: Failed to install Python packages!"
+        echo "This usually means system dependencies are missing."
+        exit 1
+    }
+fi
+echo "✓ Python packages available"
 
 echo ""
 echo "[7/8] Adding user to 'input' group..."
@@ -285,16 +312,18 @@ Description=TimeBomb - Floating Timer/Stopwatch
 Documentation=https://github.com/caffienerd/timebomb
 After=graphical-session.target
 PartOf=graphical-session.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 Type=simple
 WorkingDirectory=$PYTHON_DIR
-Environment="GDK_BACKEND=x11"
+Environment="GDK_BACKEND=wayland,x11"
 ExecStart=$VENV_DIR/bin/python3 $PYTHON_DIR/timebomb.py
 Restart=on-failure
 RestartSec=5
-StandardOutput=append:$SCRIPT_DIR/assets/logs/service.log
-StandardError=append:$SCRIPT_DIR/assets/logs/service.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=graphical-session.target
@@ -334,7 +363,7 @@ else
     echo "⊘ Skipping systemd service setup"
     echo ""
     echo "You can run TimeBomb manually with:"
-    echo "  cd $PYTHON_DIR && env GDK_BACKEND=x11 $VENV_DIR/bin/python3 timebomb.py"
+    echo "  cd $PYTHON_DIR && env GDK_BACKEND=wayland,x11 $VENV_DIR/bin/python3 timebomb.py"
     echo ""
     echo "Or set up the service later by re-running this installer."
 fi

--- a/Linux/python/app_manager.py
+++ b/Linux/python/app_manager.py
@@ -29,12 +29,98 @@ class AppManager:
         os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
         
         self.gui.save_callback = self.save_state
+        self.gui.context_menu_provider = self.get_context_menu_items
         
         self.load_state()
     
     def get_current(self):
         """Get the current active mode instance"""
         return self.stopwatch if self.mode == "stopwatch" else self.timer
+
+    def show(self):
+        """Show the current timer/stopwatch window."""
+        if self.mode == "timer" and hasattr(self.timer, 'alarm_gui') and self.timer.alarm_gui:
+            self.timer.alarm_gui.present()
+            return
+
+        current = self.get_current()
+        if current.visible:
+            self.gui.show_all()
+            self.gui.present()
+            window = self.gui.get_window()
+            if window:
+                window.raise_()
+            return
+
+        self.load_state()
+        current.start()
+
+    def hide(self):
+        """Hide the current timer/stopwatch window."""
+        current = self.get_current()
+        if current.visible:
+            self.save_state()
+            current.stop()
+
+    def show_countdown(self):
+        """Switch to countdown mode and show it."""
+        if self.mode != "timer":
+            self.switch_mode()
+        else:
+            self.show()
+
+    def show_stopwatch(self):
+        """Switch to stopwatch mode and show it."""
+        if self.mode != "stopwatch":
+            self.switch_mode()
+        else:
+            self.show()
+
+    def adjust_countdown_minutes(self, delta):
+        """Adjust the countdown by whole minutes from the context menu."""
+        if self.mode != "timer":
+            self.show_countdown()
+
+        if hasattr(self.timer, 'alarm_gui') and self.timer.alarm_gui:
+            return
+
+        if not self.timer.visible:
+            self.show()
+
+        new_minutes = max(1, min(999, self.timer.timer_minutes + delta))
+        if new_minutes == self.timer.timer_minutes and self.timer.timer_seconds == 0:
+            return
+
+        self.timer.timer_minutes = new_minutes
+        self.timer.timer_seconds = 0
+        self.timer.total_timer_seconds = self.timer.timer_minutes * 60
+        self.timer.timer_start_time = time.time()
+        self.timer.last_reset_minutes = self.timer.timer_minutes
+        self.timer.last_reset_seconds = 0
+        self.timer.below_10 = False
+        self.timer.gui.main_label.set_name("main_time")
+        self.timer.gui.main_label.set_opacity(1.0)
+        self.timer.update_display()
+        self.timer.play_sound("adjust.wav")
+
+    def get_context_menu_items(self):
+        """Return right-click menu items for the floating window."""
+        current = self.get_current()
+        reset_label = "Reset Countdown" if self.mode == "timer" else "Reset Stopwatch"
+        pause_label = "Pause / Resume Countdown" if self.mode == "timer" else "Pause / Resume Stopwatch"
+        timer_menu_enabled = self.mode == "timer" and self.timer.visible
+        alarm_active = self.mode == "timer" and hasattr(self.timer, 'alarm_gui') and self.timer.alarm_gui
+
+        return [
+            ("Countdown Mode", self.show_countdown, self.mode != "timer"),
+            ("Stopwatch Mode", self.show_stopwatch, self.mode != "stopwatch"),
+            None,
+            (reset_label, self.reset, current.visible),
+            (pause_label, self.pause, current.visible and not alarm_active),
+            None,
+            ("+1 min", lambda: self.adjust_countdown_minutes(1), timer_menu_enabled and not alarm_active),
+            ("-1 min", lambda: self.adjust_countdown_minutes(-1), timer_menu_enabled and not alarm_active),
+        ]
     
     def toggle(self):
         """Toggle visibility of current mode"""
@@ -47,11 +133,9 @@ class AppManager:
             return
         
         if current.visible:
-            self.save_state()
-            current.stop()
+            self.hide()
         else:
-            self.load_state()
-            current.start()
+            self.show()
     
     def pause(self):
         """Pause/resume current mode"""
@@ -223,11 +307,13 @@ class AppManager:
             config['General'] = {}
         config['General']['mode'] = self.mode
 
-        x, y = self.gui.get_position()
-        if 'Position' not in config:
-            config['Position'] = {}
-        config['Position']['x'] = str(x)
-        config['Position']['y'] = str(y)
+        current = self.get_current()
+        if current.visible:
+            x, y = self.gui.get_position()
+            if 'Position' not in config:
+                config['Position'] = {}
+            config['Position']['x'] = str(x)
+            config['Position']['y'] = str(y)
 
         with open(self.config_file, 'w') as f:
             config.write(f)

--- a/Linux/python/gui.py
+++ b/Linux/python/gui.py
@@ -99,6 +99,11 @@ class AppGUI(Gtk.Window):
         # Detect if we're on Wayland
         display = Gdk.Display.get_default()
         self.is_wayland = display and type(display).__name__ == 'GdkWaylandDisplay'
+        self.uses_layer_shell = self.is_wayland and HAS_LAYER_SHELL
+        self.layer_shell_x = 0
+        self.layer_shell_y = 0
+        self.context_menu_provider = None
+        self.context_menu = None
         
         self.logger.info(f"Display type: {'Wayland' if self.is_wayland else 'X11'}")
         self.logger.info(f"Layer Shell available: {HAS_LAYER_SHELL}")
@@ -110,7 +115,7 @@ class AppGUI(Gtk.Window):
         self.set_accept_focus(False)
         
         # Apply Layer Shell if on Wayland and available
-        if self.is_wayland and HAS_LAYER_SHELL:
+        if self.uses_layer_shell:
             self._setup_layer_shell()
         else:
             self._setup_fallback()
@@ -129,6 +134,7 @@ class AppGUI(Gtk.Window):
         # Frame holder
         frame = Gtk.EventBox()
         frame.set_name("box")
+        self.drag_handle = frame
         self.add(frame)
 
         # Layout
@@ -176,17 +182,20 @@ class AppGUI(Gtk.Window):
         # Set to OVERLAY layer - this is ABOVE fullscreen apps!
         GtkLayerShell.set_layer(self, GtkLayerShell.Layer.OVERLAY)
         
-        # Don't anchor to any edge (free-floating)
-        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.TOP, False)
+        # Wayland layer-shell surfaces are positioned with anchors and margins.
+        # Anchor top-left and update those margins when the user drags.
+        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.TOP, True)
         GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.BOTTOM, False)
-        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.LEFT, False)
+        GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.LEFT, True)
         GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.RIGHT, False)
+        GtkLayerShell.set_margin(self, GtkLayerShell.Edge.TOP, 0)
+        GtkLayerShell.set_margin(self, GtkLayerShell.Edge.LEFT, 0)
         
         # Set namespace
         GtkLayerShell.set_namespace(self, "timebomb")
         
-        # Disable exclusive zone (don't push other windows)
-        GtkLayerShell.auto_exclusive_zone_enable(self)
+        # Do not reserve panel space; this is an overlay.
+        GtkLayerShell.set_exclusive_zone(self, 0)
         
         self.logger.info("Layer Shell configured - window will be above fullscreen apps")
     
@@ -207,6 +216,25 @@ class AppGUI(Gtk.Window):
         if window:
             window.set_override_redirect(True)
             window.raise_()
+
+    def move(self, x, y):
+        """Move the window using the active backend's positioning model."""
+        if self.uses_layer_shell:
+            self.layer_shell_x = int(x)
+            self.layer_shell_y = int(y)
+            screen_x, screen_y, _, _ = self.get_screen_bounds()
+            GtkLayerShell.set_margin(self, GtkLayerShell.Edge.LEFT, max(0, self.layer_shell_x - screen_x))
+            GtkLayerShell.set_margin(self, GtkLayerShell.Edge.TOP, max(0, self.layer_shell_y - screen_y))
+            return
+
+        Gtk.Window.move(self, int(x), int(y))
+
+    def get_position(self):
+        """Return the saved backend position."""
+        if self.uses_layer_shell:
+            return self.layer_shell_x, self.layer_shell_y
+
+        return Gtk.Window.get_position(self)
 
     def get_screen_bounds(self):
         """Get the usable screen dimensions"""
@@ -257,6 +285,7 @@ class AppGUI(Gtk.Window):
 
     def apply_css(self):
         fonts = self.scaler.get_font_sizes()
+        menu_font_size = max(8, fonts['prefix'] - 12)
         
         css = f"""
         window {{ background: transparent; }}
@@ -298,6 +327,41 @@ class AppGUI(Gtk.Window):
             font-size: {fonts['prefix']}px;
             color: #A0FFA0;
         }}
+
+        #timebomb_context_menu {{
+            background-color: rgba(64,64,69,0.96);
+            border: 1px solid rgba(10,10,12,0.95);
+            padding: 4px;
+        }}
+
+        #timebomb_context_menu menuitem {{
+            background-color: rgba(64,64,69,0.96);
+            color: #A0FFA0;
+            min-height: 24px;
+            padding: 5px 14px;
+        }}
+
+        #timebomb_context_menu menuitem:hover {{
+            background-color: rgba(80,80,85,0.98);
+        }}
+
+        #timebomb_context_menu menuitem:disabled {{
+            color: rgba(160,255,160,0.38);
+        }}
+
+        #timebomb_context_menu menuitem label {{
+            background: transparent;
+            color: inherit;
+            font-family: Arial;
+            font-size: {menu_font_size}px;
+            font-weight: bold;
+        }}
+
+        #timebomb_context_menu separator {{
+            background-color: rgba(35,255,35,0.35);
+            min-height: 1px;
+            margin: 4px 8px;
+        }}
         """.encode()
 
         provider = Gtk.CssProvider()
@@ -311,14 +375,15 @@ class AppGUI(Gtk.Window):
 
     def enable_drag(self):
         self.dragging = False
-        self.add_events(
+        target = getattr(self, 'drag_handle', self)
+        target.add_events(
             Gdk.EventMask.BUTTON_PRESS_MASK |
             Gdk.EventMask.POINTER_MOTION_MASK |
             Gdk.EventMask.BUTTON_RELEASE_MASK
         )
-        self.connect("button-press-event", self.on_press)
-        self.connect("motion-notify-event", self.on_drag)
-        self.connect("button-release-event", self.on_release)
+        target.connect("button-press-event", self.on_press)
+        target.connect("motion-notify-event", self.on_drag)
+        target.connect("button-release-event", self.on_release)
     
     def check_and_raise(self):
         """Periodically check if we need to raise the window"""
@@ -338,19 +403,66 @@ class AppGUI(Gtk.Window):
         if not (self.is_wayland and HAS_LAYER_SHELL):
             GLib.timeout_add(500, self.check_and_raise)
 
+    def get_pointer_position(self, event):
+        """Get pointer coordinates in screen space when the backend exposes them."""
+        try:
+            display = Gdk.Display.get_default()
+            seat = display.get_default_seat() if display else None
+            pointer = seat.get_pointer() if seat else None
+            if pointer:
+                _, x, y = pointer.get_position()
+                return float(x), float(y)
+        except Exception:
+            pass
+
+        return float(event.x_root), float(event.y_root)
+
     def on_press(self, widget, event):
+        if event.button == 3:
+            return self.show_context_menu(event)
+
         if event.button == 1:
             self.dragging = True
+            pointer_x, pointer_y = self.get_pointer_position(event)
             win_x, win_y = self.get_position()
-            self.offset_x = event.x_root - win_x
-            self.offset_y = event.y_root - win_y
+            self.offset_x = pointer_x - win_x
+            self.offset_y = pointer_y - win_y
+        return True
+
+    def show_context_menu(self, event):
+        provider = getattr(self, 'context_menu_provider', None)
+        if not provider:
+            return True
+
+        menu = Gtk.Menu()
+        menu.set_name("timebomb_context_menu")
+        for item in provider():
+            if item is None:
+                separator = Gtk.SeparatorMenuItem()
+                menu.append(separator)
+                continue
+
+            label, callback, sensitive = item
+            menu_item = Gtk.MenuItem(label=label)
+            menu_item.get_style_context().add_class("timebomb-context-item")
+            menu_item.set_sensitive(bool(sensitive))
+            menu_item.connect("activate", lambda _item, cb=callback: cb())
+            menu.append(menu_item)
+
+        self.context_menu = menu
+        menu.show_all()
+        if hasattr(menu, "popup_at_pointer"):
+            menu.popup_at_pointer(event)
+        else:
+            menu.popup(None, None, None, None, event.button, event.time)
         return True
 
     def on_drag(self, widget, event):
         if self.dragging:
+            pointer_x, pointer_y = self.get_pointer_position(event)
             # Calculate new position
-            new_x = int(event.x_root - self.offset_x)
-            new_y = int(event.y_root - self.offset_y)
+            new_x = int(pointer_x - self.offset_x)
+            new_y = int(pointer_y - self.offset_y)
             
             # Constrain to screen bounds
             constrained_x, constrained_y = self.constrain_to_screen(new_x, new_y)

--- a/Linux/python/timebomb.py
+++ b/Linux/python/timebomb.py
@@ -1,12 +1,133 @@
 #!/usr/bin/env python3
+import argparse
 import sys
 import logging
 import os
+import socket
+import threading
 from pathlib import Path
 from datetime import datetime
 
-# Force X11 backend - MUST be before importing Gtk
-os.environ['GDK_BACKEND'] = 'x11'
+# Choose GTK backend before importing Gtk. Prefer native Wayland so
+# GtkLayerShell can work, but allow X11 fallback and user overrides.
+os.environ.setdefault('GDK_BACKEND', 'wayland,x11')
+
+
+def get_control_socket_path():
+    """Return the per-user socket used by launcher shortcuts."""
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if not runtime_dir:
+        user_runtime_dir = Path("/run/user") / str(os.getuid())
+        if user_runtime_dir.is_dir():
+            runtime_dir = str(user_runtime_dir)
+    if runtime_dir:
+        return Path(runtime_dir) / "timebomb.sock"
+    return Path.home() / ".cache" / "timebomb" / "timebomb.sock"
+
+
+def send_control_command(command, timeout=1.0):
+    """Send a command to the running TimeBomb instance."""
+    socket_path = get_control_socket_path()
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout)
+            client.connect(str(socket_path))
+            client.sendall(f"{command}\n".encode("utf-8"))
+            response = client.recv(128).decode("utf-8", errors="replace").strip()
+            return response == "ok"
+    except OSError:
+        return False
+
+
+class ControlServer:
+    """Small local command server for desktop launchers."""
+    def __init__(self, app_manager, glib, logger):
+        self.app_manager = app_manager
+        self.glib = glib
+        self.logger = logger
+        self.socket_path = get_control_socket_path()
+        self.server = None
+        self.running = False
+        self.thread = None
+
+    def start(self):
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.socket_path.exists():
+            if send_control_command("ping", timeout=0.2):
+                raise RuntimeError(f"TimeBomb is already running at {self.socket_path}")
+            self.socket_path.unlink()
+
+        self.server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server.settimeout(0.5)
+        self.server.bind(str(self.socket_path))
+        self.server.listen(4)
+        self.running = True
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+        self.logger.info(f"Control socket listening at {self.socket_path}")
+
+    def stop(self):
+        self.running = False
+        if self.server:
+            try:
+                self.server.close()
+            except OSError:
+                pass
+            self.server = None
+
+        try:
+            if self.socket_path.exists():
+                self.socket_path.unlink()
+        except OSError as e:
+            self.logger.warning(f"Could not remove control socket: {e}")
+
+    def _serve(self):
+        while self.running:
+            try:
+                conn, _ = self.server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            with conn:
+                try:
+                    command = conn.recv(128).decode("utf-8", errors="replace").strip().lower()
+                    ok = self._handle_command(command)
+                    conn.sendall(b"ok\n" if ok else b"unknown\n")
+                except OSError as e:
+                    self.logger.warning(f"Control socket error: {e}")
+
+    def _handle_command(self, command):
+        if command == "ping":
+            return True
+
+        actions = {
+            "show": self.app_manager.show,
+            "hide": self.app_manager.hide,
+            "toggle": self.app_manager.toggle,
+        }
+        action = actions.get(command)
+        if not action:
+            return False
+
+        def run_action():
+            action()
+            return False
+
+        self.glib.idle_add(run_action)
+        self.logger.info(f"Queued control command: {command}")
+        return True
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="TimeBomb floating timer/stopwatch")
+    command_group = parser.add_mutually_exclusive_group()
+    command_group.add_argument("--show", action="store_true", help="show the running TimeBomb window")
+    command_group.add_argument("--hide", action="store_true", help="hide the running TimeBomb window")
+    command_group.add_argument("--toggle", action="store_true", help="toggle the running TimeBomb window")
+    command_group.add_argument("--ping", action="store_true", help="check whether TimeBomb is already running")
+    return parser.parse_args()
 
 def setup_logging():
     """Setup logging to file and console"""
@@ -45,6 +166,20 @@ def cleanup_old_logs(log_dir, days=30):
         print(f"Warning: Could not clean up old logs: {e}")
 
 def main():
+    args = parse_args()
+    command = None
+    if args.show:
+        command = "show"
+    elif args.hide:
+        command = "hide"
+    elif args.toggle:
+        command = "toggle"
+    elif args.ping:
+        command = "ping"
+
+    if command:
+        sys.exit(0 if send_control_command(command) else 1)
+
     logger = setup_logging()
     logger.info("=" * 60)
     logger.info("TimeBomb starting...")
@@ -53,7 +188,7 @@ def main():
     try:
         import gi
         gi.require_version("Gtk", "3.0")
-        from gi.repository import Gtk, Gdk
+        from gi.repository import Gtk, Gdk, GLib
         logger.info("GTK imported successfully")
     except Exception as e:
         logger.error(f"Failed to import GTK: {e}")
@@ -89,10 +224,13 @@ def main():
     gui = None
     app_manager = None
     hotkeys = None
+    control_server = None
     
     try:
         gui = AppGUI()
         app_manager = AppManager(gui)
+        control_server = ControlServer(app_manager, GLib, logger)
+        control_server.start()
         hotkeys = HotkeyManager(app_manager)
         
         if not hotkeys.start():
@@ -108,6 +246,8 @@ def main():
         sys.exit(1)
     finally:
         try:
+            if control_server:
+                control_server.stop()
             if hotkeys:
                 hotkeys.stop()
             if app_manager:

--- a/Linux/timebomb-launcher.sh
+++ b/Linux/timebomb-launcher.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PYTHON_DIR="$SCRIPT_DIR/python"
+APP="$PYTHON_DIR/timebomb.py"
+PYTHON="$PYTHON_DIR/venv/bin/python3"
+
+if [ ! -x "$PYTHON" ]; then
+    PYTHON="/usr/bin/python3"
+fi
+
+show_timebomb() {
+    "$PYTHON" "$APP" --show >/dev/null 2>&1
+}
+
+if show_timebomb; then
+    exit 0
+fi
+
+SERVICE_AVAILABLE=false
+if command -v systemctl >/dev/null 2>&1; then
+    if systemctl --user start timebomb.service >/dev/null 2>&1; then
+        SERVICE_AVAILABLE=true
+    fi
+fi
+
+i=0
+while [ "$i" -lt 25 ]; do
+    sleep 0.2
+    if show_timebomb; then
+        exit 0
+    fi
+    i=$((i + 1))
+done
+
+if [ "$SERVICE_AVAILABLE" = true ]; then
+    exit 1
+fi
+
+env GDK_BACKEND=wayland,x11 "$PYTHON" "$APP" >/dev/null 2>&1 &
+
+i=0
+while [ "$i" -lt 25 ]; do
+    sleep 0.2
+    if show_timebomb; then
+        exit 0
+    fi
+    i=$((i + 1))
+done
+
+exit 1

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ Linux/
 │   │   └── state.ini       # Window position and mode
 │   └── logs/               # Application logs (auto-generated)
 │       ├── .gitkeep
-│       ├── timebomb_YYYYMMDD.log  # Daily logs
-│       └── autostart.log   # Autostart debug log
+│       └── timebomb_YYYYMMDD.log  # Daily logs
 └── python/
     ├── venv/               # Virtual environment (auto-generated)
     ├── app_manager.py      # App state management
@@ -165,45 +164,55 @@ The install script handles:
 
 #### Autostart Configuration
 
-The install script can set up TimeBomb to start automatically on login using XDG autostart (works on all distros and desktop environments).
+The install script can set up TimeBomb to start automatically on login using a systemd user service.
 
 **Features:**
-- 12-second startup delay to ensure desktop environment is ready
-- Automatic retry logic (waits up to 20 seconds for display)
-- Comprehensive logging for debugging startup issues
-- Logs saved to `assets/logs/autostart.log`
+- Starts with `graphical-session.target`
+- Uses `GDK_BACKEND=wayland,x11` so Wayland sessions can use GtkLayerShell
+- Restarts on failure, with rate limiting to avoid endless restart storms
+- Logs to the systemd journal and daily files in `assets/logs/`
 
-**Manual autostart setup:**
+**Manual systemd setup:**
 
 If you skipped autostart during installation:
 
 ```bash
-mkdir -p ~/.config/autostart
+mkdir -p ~/.config/systemd/user
 
-cat > ~/.config/autostart/timebomb.desktop <<'EOF'
-[Desktop Entry]
-Type=Application
-Name=TimeBomb
-Comment=Floating Timer/Stopwatch
-Exec=bash -c "sleep 12 && env GDK_BACKEND=x11 /path/to/timebomb/Linux/python/venv/bin/python3 /path/to/timebomb/Linux/python/timebomb.py >> /path/to/timebomb/Linux/assets/logs/autostart.log 2>&1"
-Terminal=false
-StartupNotify=false
-Hidden=false
-NoDisplay=false
-X-GNOME-Autostart-enabled=true
-X-GNOME-Autostart-Delay=12
-Categories=Utility;
-Keywords=timer;stopwatch;clock;
+cat > ~/.config/systemd/user/timebomb.service <<'EOF'
+[Unit]
+Description=TimeBomb - Floating Timer/Stopwatch
+Documentation=https://github.com/caffienerd/timebomb
+After=graphical-session.target
+PartOf=graphical-session.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/timebomb/Linux/python
+Environment="GDK_BACKEND=wayland,x11"
+ExecStart=/path/to/timebomb/Linux/python/venv/bin/python3 /path/to/timebomb/Linux/python/timebomb.py
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=graphical-session.target
 EOF
 
-chmod 644 ~/.config/autostart/timebomb.desktop
+systemctl --user daemon-reload
+systemctl --user enable --now timebomb.service
 ```
 
 **Important:** Replace `/path/to/timebomb/` with your actual TimeBomb installation directory.
 
 To disable autostart:
 ```bash
-rm ~/.config/autostart/timebomb.desktop
+systemctl --user disable --now timebomb.service
+rm ~/.config/systemd/user/timebomb.service
+systemctl --user daemon-reload
 ```
 
 #### Logging System
@@ -215,17 +224,17 @@ TimeBomb includes comprehensive logging to help debug issues:
   - Automatic cleanup (keeps last 30 days)
   - Contains all app events and errors
 
-- **Autostart log:** `assets/logs/autostart.log`
-  - Captures startup output when launched via autostart
-  - Useful for debugging boot issues
+- **Systemd journal:** `journalctl --user -u timebomb.service`
+  - Captures service lifecycle and startup output
+  - Useful for debugging login startup issues
 
 **View logs:**
 ```bash
 # View today's log
 tail -f ~/path/to/timebomb/Linux/assets/logs/timebomb_$(date +%Y%m%d).log
 
-# View autostart log
-cat ~/path/to/timebomb/Linux/assets/logs/autostart.log
+# View service logs
+journalctl --user -u timebomb.service -f
 
 # List all logs
 ls -lh ~/path/to/timebomb/Linux/assets/logs/
@@ -297,9 +306,9 @@ Just delete the folder. If you added it to startup, remove the shortcut from the
 ### Linux
 
 **TimeBomb doesn't start on login:**
-- Check autostart log: `cat ~/path/to/timebomb/Linux/assets/logs/autostart.log`
-- Verify desktop file exists: `ls ~/.config/autostart/timebomb.desktop`
-- Check permissions: Desktop file should NOT be executable (`-rw-r--r--`)
+- Check service status: `systemctl --user status timebomb.service`
+- View service logs: `journalctl --user -u timebomb.service -n 100 --no-pager`
+- Verify the service points at your current checkout: `systemctl --user cat timebomb.service`
 
 **Keyboard shortcuts not working:**
 - Ensure you're in the `input` group: `groups | grep input`
@@ -307,9 +316,9 @@ Just delete the folder. If you added it to startup, remove the shortcut from the
 - Log out and back in for changes to take effect
 
 **GTK initialization errors:**
-- Check if display is ready: The app waits up to 20 seconds for GTK to initialize
-- View logs to see retry attempts
-- If using autostart, ensure the 12-second delay is sufficient for your system
+- Check whether the service is using the expected backend: `systemctl --user cat timebomb.service`
+- On Wayland, prefer `GDK_BACKEND=wayland,x11` so GtkLayerShell can initialize
+- View logs for the exact display/backend error
 
 **Viewing debug information:**
 ```bash
@@ -320,7 +329,7 @@ ps aux | grep timebomb
 tail -f ~/path/to/timebomb/Linux/assets/logs/timebomb_$(date +%Y%m%d).log
 
 # Check autostart configuration
-cat ~/.config/autostart/timebomb.desktop
+systemctl --user cat timebomb.service
 ```
 
 ### Windows
@@ -342,7 +351,7 @@ TimeBomb uses Win+key combos because it's the only modifier not heavily used by 
 - Threaded keyboard listener to avoid blocking the GUI
 - Hot-plug support for USB keyboards
 - Comprehensive logging with automatic rotation and cleanup
-- Graceful startup with retry logic for autostart reliability
+- Systemd user service for login startup
 
 ### Windows
 - Built with AutoHotkey


### PR DESCRIPTION
## Summary

- Make Linux startup use a systemd user service with Wayland/X11 backend fallback and journal logging.
- Add a local control socket plus launcher support so desktop shortcuts show the existing TimeBomb instance instead of spawning duplicates.
- Make the floating timer movable under layer-shell and add themed right-click countdown/stopwatch controls.

## Impact

This improves login startup reliability, desktop launcher behavior, and day-to-day timer control from the floating window.

## Root Cause

The Linux app forced X11 and did not expose a desktop-safe way to activate an existing Wayland/layer-shell instance. Layer-shell positioning also needed margin-based movement instead of regular window moves.

## Validation

- `bash -n Linux/install.sh`
- `sh -n Linux/timebomb-launcher.sh`
- `Linux/python/venv/bin/python3 -m py_compile Linux/python/timebomb.py Linux/python/app_manager.py Linux/python/gui.py`
